### PR TITLE
Add support for custom changelog template and fix security vulnerability

### DIFF
--- a/.changes/next-release/minor-20210326133507277741.json
+++ b/.changes/next-release/minor-20210326133507277741.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Add support for custom changelog template"
+}

--- a/.changes/next-release/patch-20210325115332579162.json
+++ b/.changes/next-release/patch-20210325115332579162.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix security vulnerability with jinja2 CVE-2020-28493"
+}

--- a/README.md
+++ b/README.md
@@ -54,10 +54,31 @@ $ semversioner release
 
 ### Generating Changelog
 
-As a part of your CI/CD workflow, you will be able to generate the Changelog file with all changes.
+As a part of your CI/CD workflow, you will be able to generate the changelog file with all changes.
 
 ```shell
 $ semversioner changelog > CHANGELOG.md
+```
+
+You can customize the changelog by creating a template and passing it as parameter to the command. For example:
+
+```shell
+$ semversioner changelog --template .semversioner/config/template.j2
+```
+
+The template is using [Jinja2](https://jinja.palletsprojects.com/en/2.11.x/), a templating language for Python. For example:
+
+```
+# Changelog
+{% for release in releases %}
+
+## {{ release.version }}
+
+{% for change in release.changes %}
+- {{ change.type }}: {{ change.description }}
+{% endfor %}
+{% endfor %}
+
 ```
 
 You can filter the changelog by only showing changes for a specific version:
@@ -73,7 +94,7 @@ $ semversioner changelog --version $(semversioner current-version)
 ```
 
 ## License
-Copyright (c) 2020 Raul Gomis.
+Copyright (c) 2021 Raul Gomis.
 MIT licensed, see [LICENSE](LICENSE) file.
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ twine==3.2.0
 wheel==0.34.2
 jinja2==2.11.3
 colorama==0.4.3
+importlib_resources==5.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pytest==6.2.1
 click==7.1.2
 twine==3.2.0
 wheel==0.34.2
-jinja2==2.11.2
+jinja2==2.11.3
 colorama==0.4.3

--- a/semversioner/cli.py
+++ b/semversioner/cli.py
@@ -37,7 +37,7 @@ ROOTDIR = os.getcwd()
 
 
 @click.group()
-@click.option('--path', default=ROOTDIR, help="Base path. Default to current directory.")
+@click.option('--path', default=ROOTDIR, help="Base path. Default to current directory.", type=click.Path(exists=True))
 @click.version_option(version=str(__version__.__version__))
 @click.pass_context
 def cli(ctx, path):
@@ -60,10 +60,14 @@ def cli_release(ctx):
 
 @cli.command('changelog', help="Print the changelog.")
 @click.option('--version', default=None, help="Filter the changelog by version.")
+@click.option('--template', default=None, help="Path to a custom changelog template.", type=click.File('r'))
 @click.pass_context
-def cli_changelog(ctx, version):
+def cli_changelog(ctx, version, template):
     releaser = ctx.obj['releaser']
-    changelog = releaser.generate_changelog(version=version)
+    if template:
+        changelog = releaser.generate_changelog(version=version, template=template.read())
+    else:
+        changelog = releaser.generate_changelog(version=version)
     click.echo(message=changelog, nl=False)
 
 

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -47,7 +47,7 @@ class Semversioner:
 
         return self.fs.create_changeset(change_type=change_type, description=description)
 
-    def generate_changelog(self, version=None):
+    def generate_changelog(self, version=None, template=DEFAULT_TEMPLATE):
         """ 
         Generates the changelog.
 
@@ -64,7 +64,7 @@ class Semversioner:
         if version is not None:
             releases = [x for x in releases if x['version'] == version]
 
-        return Template(DEFAULT_TEMPLATE, trim_blocks=True).render(releases=releases)
+        return Template(template, trim_blocks=True).render(releases=releases)
 
     def release(self):
         """ 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from semversioner.cli import cli
 from semversioner import __version__
 from tests import fixtures
-import importlib.resources
+from importlib_resources import files
 
 
 def command_processor(commands, path):
@@ -22,14 +22,11 @@ def command_processor(commands, path):
 
 
 def get_file(filename):
-    path = None
-    with importlib.resources.path('tests.resources', filename) as p:
-        path = p
-    return path
+    return files('tests.resources').joinpath(filename)
 
 
 def read_file(filename):
-    return importlib.resources.read_text('tests.resources', filename)
+    return files('tests.resources').joinpath(filename).read_text()
 
 
 class CommandTest(unittest.TestCase):

--- a/tests/resources/template_01.j2
+++ b/tests/resources/template_01.j2
@@ -1,0 +1,9 @@
+# Changelog
+{% for release in releases %}
+
+## {{ release.version }}
+
+{% for change in release.changes %}
+- {{ change.type }}: {{ change.description }}
+{% endfor %}
+{% endfor %}

--- a/tests/resources/template_01_readme.md
+++ b/tests/resources/template_01_readme.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 2.0.0
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description
+
+## 1.0.0
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description

--- a/tests/resources/template_02.j2
+++ b/tests/resources/template_02.j2
@@ -1,0 +1,10 @@
+# Changelog
+Note: version releases in the 0.x.y range may introduce breaking changes.
+{% for release in releases %}
+
+## {{ release.version }} (<DATE>)
+
+{% for change in release.changes %}
+- {{ change.type }}: {{ change.description }}
+{% endfor %}
+{% endfor %}

--- a/tests/resources/template_02_readme.md
+++ b/tests/resources/template_02_readme.md
@@ -1,0 +1,14 @@
+# Changelog
+Note: version releases in the 0.x.y range may introduce breaking changes.
+
+## 2.0.0 (<DATE>)
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description
+
+## 1.0.0 (<DATE>)
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description


### PR DESCRIPTION
Closes #8 

Pass a parameter to the `semversioner changelog` command. For example, it would look like this:
```
semversioner changelog --template my/path/semversioner_template.j2
```
This option allows multiple representations of the changelog for the same repository during the CI/CD process as you could have (`semversioner changelog --template my/path/template1.j2` and `semversioner changelog --template my/path/template2.j2` For example, you might want to publish a CHANGELOG.md with one format but also publish an HTML page with the release notes or Github releases.