### PR TITLE
Fix/windows testing

### DIFF
--- a/.semversioner/next-release/patch-20221019085748511887.json
+++ b/.semversioner/next-release/patch-20221019085748511887.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "All tests are now able to be run on Windows"
+}

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -95,7 +95,7 @@ class ReleaseCommandTest(CommandTest):
         ]
 
         result = command_processor(commands, self.directory_name)
-        self.assertEqual(result.output, f"Releasing version: 0.0.0 -> 1.0.0\nGenerated '{self.changes_dirname}/1.0.0.json' file.\nRemoving '{self.next_release_dirname}' directory.\nSuccessfully created new release: 1.0.0\n")
+        self.assertEqual(result.output, f"Releasing version: 0.0.0 -> 1.0.0\nGenerated '{os.path.join(self.changes_dirname, '1.0.0.json')}' file.\nRemoving '{self.next_release_dirname}' directory.\nSuccessfully created new release: 1.0.0\n")
 
 
 class ChangelogCommandTest(CommandTest):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import tempfile
 import unittest
@@ -81,7 +82,7 @@ class AddChangeCommandTest(CommandTest):
         ]
 
         self.assertListEqual(expected, data)
-        self.assertRegex(result.output, f"Successfully created file {self.next_release_dirname}.*\\.json")
+        self.assertRegex(result.output, f"Successfully created file {re.escape(self.next_release_dirname)}.*\.json")
 
 
 class ReleaseCommandTest(CommandTest):


### PR DESCRIPTION
Some of the internal testing in semversioner fails in Windows, due to how paths are combined. I've fixed the two cases, which did not yield a successful test on my Windows machine.

N.B.: As this is internal stuff, I don't think this should result in a release.