### PR TITLE
Feature/add support for dates

### DIFF
--- a/.semversioner/next-release/minor-20221203131113831932.json
+++ b/.semversioner/next-release/minor-20221203131113831932.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Add support for storing release datetime in order to display it in the changelog."
+}

--- a/.semversioner/next-release/patch-20221203131731747922.json
+++ b/.semversioner/next-release/patch-20221203131731747922.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix: bug showing incorrect error using release command with no changesets created."
+}

--- a/semversioner/cli.py
+++ b/semversioner/cli.py
@@ -62,9 +62,9 @@ def cli_release(ctx: click.Context) -> None:
         click.echo("Semversioner now uses '.semversioner' directory instead of '.changes'. Please, rename it to remove this message.")
     try:
         result: Release = releaser.release()
+        click.echo(message="Successfully created new release: " + result.version)
     except MissingChangesetException:
         click.secho("Error: No changes to release. Skipping release process.", fg='red')
-    click.echo(message="Successfully created new release: " + result.version)
 
 
 @cli.command('changelog', help="Print the changelog.")

--- a/semversioner/models.py
+++ b/semversioner/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
@@ -42,6 +43,7 @@ class Release:
     """
     version: str
     changes: List[Changeset]
+    created_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -18,7 +18,7 @@ class SemversionerStorage(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def create_changeset(self, change_type: str, description: str) -> str:
+    def create_changeset(self, change: Changeset) -> str:
         pass
 
     @abstractmethod
@@ -30,7 +30,7 @@ class SemversionerStorage(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def create_version(self, version: str, changes: List[Changeset]) -> None:
+    def create_version(self, release: Release) -> None:
         pass
 
     @abstractmethod
@@ -47,6 +47,36 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
         return super().default(o)
+
+
+class ReleaseJsonMapper:
+    """
+    Release Json Mapper class
+    """
+
+    @staticmethod
+    def to_json(release: Release) -> str:
+        data = {
+            'version': release.version,
+            'created_at': release.created_at.isoformat(),
+            'changes': release.changes
+        }
+
+        return json.dumps(data, cls=EnhancedJSONEncoder, indent=2, sort_keys=True)
+
+    @staticmethod
+    def from_json(data: dict, release_identifier: str) -> Release:
+        created_at: datetime = None
+
+        if 'created_at' in data:  # New format
+            created_at = datetime.datetime.fromisoformat(data['created_at'])
+            version = data['version']
+            changes = sorted(data['changes'], key=lambda k: k['type'] + k['description'])  # type: ignore
+        else:
+            changes = sorted(data, key=lambda k: k['type'] + k['description'])  # type: ignore
+            version = release_identifier
+
+        return Release(version=version, changes=changes, created_at=created_at)
 
 
 class SemversionerFileSystemStorage(SemversionerStorage):
@@ -75,7 +105,7 @@ class SemversionerFileSystemStorage(SemversionerStorage):
     def is_deprecated(self) -> bool:
         return self.deprecated
 
-    def create_changeset(self, change_type: str, description: str) -> str:
+    def create_changeset(self, change: Changeset) -> str:
         """ 
         Create a new changeset file.
 
@@ -84,16 +114,13 @@ class SemversionerFileSystemStorage(SemversionerStorage):
 
         Parameters
         -------
-        change_type (str): Change type. Allowed values: major, minor, patch.
-        description (str): Change description.
+        change (Changeset): Changeset.
 
         Returns
         -------
         path : str
             Absolute path of the file generated.
         """
-
-        change = Changeset(type=change_type, description=description)
 
         filename = None
         while (filename is None or os.path.isfile(os.path.join(self.next_release_path, filename))):
@@ -128,10 +155,11 @@ class SemversionerFileSystemStorage(SemversionerStorage):
         changes = sorted(changes, key=lambda k: k.type + k.description)
         return changes
 
-    def create_version(self, version: str, changes: List[Changeset]) -> None:
+    def create_version(self, release: Release) -> None:
+        version: str = release.version
         release_json_filename: str = os.path.join(self.semversioner_path, '%s.json' % version)
         with open(release_json_filename, 'w') as f:
-            f.write(json.dumps(changes, cls=EnhancedJSONEncoder, indent=2, sort_keys=True))
+            f.write(ReleaseJsonMapper.to_json(release))
         click.echo("Generated '" + release_json_filename + "' file.")
 
     def list_versions(self) -> List[Release]:
@@ -139,8 +167,7 @@ class SemversionerFileSystemStorage(SemversionerStorage):
         for release_identifier in self._list_release_numbers():
             with open(os.path.join(self.semversioner_path, release_identifier + '.json')) as f:
                 data = json.load(f)
-                data = sorted(data, key=lambda k: k['type'] + k['description'])  # type: ignore
-                releases.append(Release(version=release_identifier, changes=data))
+                releases.append(ReleaseJsonMapper.from_json(data, release_identifier))
         return releases
 
     def get_last_version(self) -> Optional[str]:

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -1,5 +1,5 @@
 import dataclasses
-import datetime
+from datetime import datetime
 import json
 import os
 from abc import ABCMeta, abstractmethod
@@ -58,7 +58,7 @@ class ReleaseJsonMapper:
     def to_json(release: Release) -> str:
         data = {
             'version': release.version,
-            'created_at': release.created_at.isoformat(),
+            'created_at': release.created_at.isoformat() if release.created_at else None,
             'changes': release.changes
         }
 
@@ -66,10 +66,10 @@ class ReleaseJsonMapper:
 
     @staticmethod
     def from_json(data: dict, release_identifier: str) -> Release:
-        created_at: datetime = None
+        created_at: Optional[datetime] = None
 
         if 'created_at' in data:  # New format
-            created_at = datetime.datetime.fromisoformat(data['created_at'])
+            created_at = datetime.fromisoformat(data['created_at'])
             version = data['version']
             changes = sorted(data['changes'], key=lambda k: k['type'] + k['description'])  # type: ignore
         else:
@@ -126,7 +126,7 @@ class SemversionerFileSystemStorage(SemversionerStorage):
         while (filename is None or os.path.isfile(os.path.join(self.next_release_path, filename))):
             filename = '{type_name}-{datetime}.json'.format(
                 type_name=change.type,
-                datetime="{:%Y%m%d%H%M%S%f}".format(datetime.datetime.utcnow())
+                datetime="{:%Y%m%d%H%M%S%f}".format(datetime.utcnow())
             )
 
         with open(os.path.join(self.next_release_path, filename), 'w') as f:


### PR DESCRIPTION
Add support for dates.

Note: It is still not included by default in the Changelog template. If you want to use dates, please use this template instead:

```
# Changelog
Note: version releases in the 0.x.y range may introduce breaking changes.
{% for release in releases %}

## {{ release.version }}{{ ' (' + release.created_at.strftime("%m-%d-%Y") + ')' if release.created_at }}

{% for change in release.changes %}
- {{ change.type }}: {{ change.description }}
{% endfor %}
{% endfor %}
```