### PR TITLE
Remove StrictVersion deprecation notice by switching to package.version parse method

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -47,7 +47,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pip install -r requirements-dev.txt
-        pip install semversioner==0.13.0
+        pip install semversioner==1.4.1
 
         previous_version=$(semversioner current-version)
         semversioner release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.semversioner/next-release/minor-20230113122551117180.json
+++ b/.semversioner/next-release/minor-20230113122551117180.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Fix remove StrictVersion deprecation notice by switching to package.version parse method."
+}

--- a/.semversioner/next-release/patch-20230113122637638563.json
+++ b/.semversioner/next-release/patch-20230113122637638563.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Internal: Support python 3.11 in Github actions."
+}

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import json
 import os
 from abc import ABCMeta, abstractmethod
-from distutils.version import StrictVersion
+from packaging.version import parse
 from typing import List, Optional
 
 import click
@@ -182,5 +182,5 @@ class SemversionerFileSystemStorage(SemversionerStorage):
 
     def _list_release_numbers(self) -> List[str]:
         files = [f for f in os.listdir(self.semversioner_path) if os.path.isfile(os.path.join(self.semversioner_path, f))]
-        releases = sorted(list(map(lambda x: x[:-len('.json')], files)), key=StrictVersion, reverse=True)
+        releases = sorted(list(map(lambda x: x[:-len('.json')], files)), key=lambda x: parse(x), reverse=True)
         return releases


### PR DESCRIPTION
- Fix remove StrictVersion deprecation notice by switching to package.version parse method. 
- Internal: Support python 3.11 in Github actions.