### PR TITLE
Upgrade dependencies and drop Python 3.7 support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pip install twine==4.0.2
-        pip install wheel==0.41.0
+        pip install wheel==0.42.0
         pip install semversioner==1.7.0
 
         previous_version=$(semversioner current-version)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -43,15 +43,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pip install twine==4.0.2
-        pip install wheel==0.38.4
-        pip install semversioner==1.5.1
+        pip install wheel==0.41.0
+        pip install semversioner==1.7.0
 
         previous_version=$(semversioner current-version)
         semversioner release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.semversioner/next-release/major-20231224051035531250.json
+++ b/.semversioner/next-release/major-20231224051035531250.json
@@ -1,0 +1,4 @@
+{
+  "type": "major",
+  "description": "Drop support for Python 3.6 and 3.7 as they are not maintained. Minimum supported version is Python 3.8."
+}

--- a/.semversioner/next-release/major-20231224051138380509.json
+++ b/.semversioner/next-release/major-20231224051138380509.json
@@ -1,0 +1,4 @@
+{
+  "type": "major",
+  "description": "Upgrade project third-party dependencies to latest version."
+}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global options:
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_return_any = True
 warn_unused_ignores = True
 show_error_codes = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==7.4.0
-importlib_resources==6.0.0
-mypy==1.4.1
-flake8==6.0.0
+pytest==7.4.3
+importlib_resources==6.1.1
+mypy==1.8.0
+flake8==6.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 pytest==7.4.0
-importlib_resources==5.12.0
+importlib_resources==6.0.0
 mypy==1.4.1
-flake8==5.0.4
+flake8==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==8.1.6
-jinja2==3.0.3
-packaging==23.1
+click==8.1.7
+jinja2==3.1.2
+packaging==23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==8.0.3
+click==8.1.6
 jinja2==3.0.3
-packaging==23.0
+packaging==23.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DESCRIPTION = 'Manage properly semver in your repository'
 URL = 'https://github.com/raulgomis/semversioner'
 EMAIL = 'raulgomis@gmail.com'
 AUTHOR = 'Raul Gomis'
-REQUIRES_PYTHON = '>=3.7.0'
+REQUIRES_PYTHON = '>=3.8.0'
 VERSION = None
 REQUIRED = [
     'click>=8.0.0',
@@ -85,7 +85,7 @@ setup(
     install_requires=REQUIRED,
 
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
 
         'Environment :: Console',
 
@@ -96,10 +96,11 @@ setup(
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
     ],
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -39,8 +39,7 @@ def get_file(filename: str) -> Path:
 
 
 def read_file(filename: str) -> str:
-    text: str = files('email.tests.data').joinpath('message.eml').read_text()
-    return text
+    return files('tests.resources').joinpath(filename).read_text()  # type: ignore
 
 
 class CommandTest(unittest.TestCase):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -34,11 +34,13 @@ def single_command_processor(command: List[str], path: str) -> Result:
 
 
 def get_file(filename: str) -> Path: 
-    return files('tests.resources').joinpath(filename)  # type: ignore
+    path: Path = files('tests.resources').joinpath(filename)
+    return path
 
 
 def read_file(filename: str) -> str:
-    return files('tests.resources').joinpath(filename).read_text()  # type: ignore
+    text: str = files('email.tests.data').joinpath('message.eml').read_text()
+    return text
 
 
 class CommandTest(unittest.TestCase):


### PR DESCRIPTION
This pull request upgrades the project's third-party dependencies to the latest version and drops support for Python 3.7, as it is no longer maintained. The minimum supported version is now Python 3.8.