### PR TITLE
Release Semversioner 2.x

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pip install twine==4.0.2
-        pip install wheel==0.41.0
+        pip install wheel==0.42.0
         pip install semversioner==1.7.0
 
         previous_version=$(semversioner current-version)

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -43,15 +43,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pip install twine==4.0.2
-        pip install wheel==0.38.4
-        pip install semversioner==1.5.1
+        pip install wheel==0.41.0
+        pip install semversioner==1.7.0
 
         previous_version=$(semversioner current-version)
         semversioner release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.semversioner/next-release/major-20231224051035531250.json
+++ b/.semversioner/next-release/major-20231224051035531250.json
@@ -1,0 +1,4 @@
+{
+  "type": "major",
+  "description": "Drop support for Python 3.6 and 3.7 as they are not maintained. Minimum supported version is Python 3.8."
+}

--- a/.semversioner/next-release/major-20231224051138380509.json
+++ b/.semversioner/next-release/major-20231224051138380509.json
@@ -1,0 +1,4 @@
+{
+  "type": "major",
+  "description": "Upgrade project third-party dependencies to latest version."
+}

--- a/.semversioner/next-release/major-20231224062500751956.json
+++ b/.semversioner/next-release/major-20231224062500751956.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Change deletion logic in `next-release` folder: only delete json files, and delete the folder only if empty. This will allow to keep the `next-release` folder if it contains other files such as `.gitkeep` for example."
+}

--- a/.semversioner/next-release/minor-20231224043259516350.json
+++ b/.semversioner/next-release/minor-20231224043259516350.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Add support for custom properties in changeset files."
+}

--- a/.semversioner/next-release/minor-20231224043423344714.json
+++ b/.semversioner/next-release/minor-20231224043423344714.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Change json mapper to use granurality of seconds instead of milliseconds for `created_at` field in releases."
+}

--- a/.semversioner/next-release/patch-20231224043232638443.json
+++ b/.semversioner/next-release/patch-20231224043232638443.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Clean up README Markdown syntax."
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Semversioner
-The easiest way to manage [semantic versioning](https://semver.org/) in your project and generate CHANGELOG.md file automatically. 
 
-Semversioner will provide the tooling to automate semver release process for libraries, docker images, etc. 
+The easiest way to manage [semantic versioning](https://semver.org/) in your project and generate CHANGELOG.md file automatically.
+
+Semversioner will provide the tooling to automate semver release process for libraries, docker images, etc.
 
 This project was inspired by the way AWS manages their versioning for [AWS-cli](https://github.com/aws/aws-cli/).
 
 ## Semantic Versioning
+
 The [semantic versioning](https://semver.org/) spec involves several possible variations, but to simplify, in _Semversioner_ we are using the three-part version number:
 
 `<major>.<minor>.<patch>`
 
 Constructed with the following guidelines:
+
 - Breaking backward compatibility or major features bumps the major (and resets the minor and patch).
 - New additions without breaking backward compatibility bumps the minor (and resets the patch).
 - Bug fixes and misc changes bumps the patch.
@@ -35,7 +38,7 @@ JSON file is a list of all the individual JSON files from ``next-release``.
 ## Install
 
 ```shell
-$ pip install semversioner
+pip install semversioner
 ```
 
 ## Usage
@@ -43,13 +46,15 @@ $ pip install semversioner
 ### Bumping the version
 
 In your local environment your will use the CLI to create the different changeset files that will be committed with your code. For example:
+
 ```shell
-$ semversioner add-change --type patch --description "Fix security vulnerability with authentication."
+semversioner add-change --type patch --description "Fix security vulnerability with authentication."
 ```
 
-Then, in your CI/CD tool you will need to release (generating automatically version number) and creating the the changelog file. 
+Then, in your CI/CD tool you will need to release (generating automatically version number) and creating the the changelog file.
+
 ```shell
-$ semversioner release
+semversioner release
 ```
 
 ### Generating Changelog
@@ -57,13 +62,13 @@ $ semversioner release
 As a part of your CI/CD workflow, you will be able to generate the changelog file with all changes.
 
 ```shell
-$ semversioner changelog > CHANGELOG.md
+semversioner changelog > CHANGELOG.md
 ```
 
 You can customize the changelog by creating a template and passing it as parameter to the command. For example:
 
 ```shell
-$ semversioner changelog --template .semversioner/config/template.j2
+semversioner changelog --template .semversioner/config/template.j2
 ```
 
 The template is using [Jinja2](https://jinja.palletsprojects.com/en/2.11.x/), a templating language for Python. For example:
@@ -84,27 +89,28 @@ The template is using [Jinja2](https://jinja.palletsprojects.com/en/2.11.x/), a 
 You can filter the changelog by only showing changes for a specific version:
 
 ```shell
-$ semversioner changelog --version "1.0.0"
+semversioner changelog --version "1.0.0"
 ```
 
 Alternatively, you can use the following command to filter changes by the last released version:
 
 ```shell
-$ semversioner changelog --version $(semversioner current-version)
+semversioner changelog --version $(semversioner current-version)
 ```
+
 ### Getting next version
 
-As part of the CI/CD workflow, sometimes you want to release dev, rc, or other pre-release packages. For this purpose, 
+As part of the CI/CD workflow, sometimes you want to release dev, rc, or other pre-release packages. For this purpose,
 the next-version command can be issued, to compute the next version based on the current change set. This will
 not change any files on disk, and they are as such preserved for any future release.
 
 ```shell
-$ semversioner next-version
+semversioner next-version
 ```
 
-
 ## License
-Copyright (c) 2021 Raul Gomis.
+
+Copyright (c) 2023 Raul Gomis.
 MIT licensed, see [LICENSE](LICENSE) file.
 
 ---

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global options:
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_return_any = True
 warn_unused_ignores = True
 show_error_codes = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==7.4.0
-importlib_resources==6.0.0
-mypy==1.4.1
-flake8==6.0.0
+pytest==7.4.3
+importlib_resources==6.1.1
+mypy==1.8.0
+flake8==6.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 pytest==7.4.0
-importlib_resources==5.12.0
+importlib_resources==6.0.0
 mypy==1.4.1
-flake8==5.0.4
+flake8==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==8.1.6
-jinja2==3.0.3
-packaging==23.1
+click==8.1.7
+jinja2==3.1.2
+packaging==23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==8.0.3
+click==8.1.6
 jinja2==3.0.3
-packaging==23.0
+packaging==23.1

--- a/semversioner/cli.py
+++ b/semversioner/cli.py
@@ -41,6 +41,17 @@ from semversioner.models import (MissingChangesetException, Release, ReleaseStat
 
 ROOTDIR = os.getcwd()
 
+def parse_key_value_pair(ctx, param, value):
+    """
+    Parses a list of strings into a dictionary where each string is a key-value pair.
+    """
+    if not value:
+        return None
+    dict_value = {}
+    for item in value:
+        key, val = item.split('=', 1)
+        dict_value[key] = val
+    return dict_value
 
 @click.group()
 @click.option('--path', default=ROOTDIR, help="Base path. Default to current directory.", type=click.Path(exists=True))
@@ -84,9 +95,10 @@ def cli_changelog(ctx: click.Context, version: Optional[str], template: TextIO) 
 @click.pass_context
 @click.option('--type', '-t', type=click.Choice(['major', 'minor', 'patch']), required=True)
 @click.option('--description', '-d', required=True)
-def cli_add_change(ctx: click.Context, type: str, description: str) -> None:
+@click.option('--attributes', multiple=True, callback=parse_key_value_pair, help='Attributes in key=value format.')
+def cli_add_change(ctx: click.Context, type: str, description: str, attributes: Optional[dict]) -> None:
     releaser: Semversioner = ctx.obj['releaser']
-    path: str = releaser.add_change(type, description)
+    path: str = releaser.add_change(type, description, attributes)
     click.echo(message="Successfully created file " + path)
 
 

--- a/semversioner/cli.py
+++ b/semversioner/cli.py
@@ -31,7 +31,7 @@ Usage
 
 import os
 import sys
-from typing import Optional, TextIO
+from typing import Dict, List, Optional, TextIO
 
 import click
 
@@ -41,7 +41,8 @@ from semversioner.models import (MissingChangesetException, Release, ReleaseStat
 
 ROOTDIR = os.getcwd()
 
-def parse_key_value_pair(ctx, param, value):
+
+def parse_key_value_pair(ctx: Optional[click.core.Context], param: Optional[click.core.Parameter], value: List[str]) -> Optional[Dict[str, str]]:
     """
     Parses a list of strings into a dictionary where each string is a key-value pair.
     """
@@ -52,6 +53,7 @@ def parse_key_value_pair(ctx, param, value):
         key, val = item.split('=', 1)
         dict_value[key] = val
     return dict_value
+
 
 @click.group()
 @click.option('--path', default=ROOTDIR, help="Base path. Default to current directory.", type=click.Path(exists=True))

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import click
 from jinja2 import Template
@@ -33,7 +33,7 @@ class Semversioner:
     def is_deprecated(self) -> bool:
         return self.fs.is_deprecated()
 
-    def add_change(self, change_type: str, description: str, attributes: dict = None) -> str:
+    def add_change(self, change_type: str, description: str, attributes: Optional[Dict[str, str]] = None) -> str:
         """ 
         Create a new changeset file.
 

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -33,7 +33,7 @@ class Semversioner:
     def is_deprecated(self) -> bool:
         return self.fs.is_deprecated()
 
-    def add_change(self, change_type: str, description: str) -> str:
+    def add_change(self, change_type: str, description: str, attributes: dict = None) -> str:
         """ 
         Create a new changeset file.
 
@@ -44,6 +44,7 @@ class Semversioner:
         -------
         change_type (str): Change type. Allowed values: major, minor, patch.
         description (str): Change description.
+        attributes (dict): Change attributes (Optional).
 
         Returns
         -------
@@ -51,7 +52,7 @@ class Semversioner:
             Absolute path of the file generated.
         """
 
-        return self.fs.create_changeset(Changeset(type=change_type, description=description))
+        return self.fs.create_changeset(Changeset(type=change_type, description=description, attributes=attributes))
 
     def generate_changelog(self, version: Optional[str] = None, template: str = DEFAULT_TEMPLATE) -> str:
         """ 

--- a/semversioner/models.py
+++ b/semversioner/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class SemversionerException(Exception):
@@ -34,7 +34,7 @@ class Changeset:
     """
     type: str
     description: str
-    attributes: dict = None
+    attributes: Optional[Dict[str, str]] = None
 
 
 @dataclass(frozen=True)

--- a/semversioner/models.py
+++ b/semversioner/models.py
@@ -34,6 +34,7 @@ class Changeset:
     """
     type: str
     description: str
+    attributes: dict = None
 
 
 @dataclass(frozen=True)

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -74,7 +74,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
     """
     def default(self, o):  # type: ignore
         if dataclasses.is_dataclass(o):
-            return dataclasses.asdict(o)
+            return dataclasses.asdict(o, dict_factory=lambda x: {k: v for (k, v) in x if v is not None})
         return super().default(o)
 
 
@@ -90,7 +90,7 @@ class ReleaseJsonMapper:
         """
         data = {
             'version': release.version,
-            'created_at': release.created_at.isoformat() if release.created_at else None,
+            'created_at': release.created_at.isoformat(timespec="seconds") if release.created_at else None,
             'changes': release.changes
         }
 

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -170,12 +170,17 @@ class SemversionerFileSystemStorage(SemversionerStorage):
         return os.path.join(self.next_release_path, filename)
 
     def remove_all_changesets(self) -> None:
-        click.echo("Removing '" + self.next_release_path + "' directory.")
+        click.echo("Removing changeset files in '" + self.next_release_path + "' directory.")
 
+        # Remove all json files in next_release_path
         for filename in os.listdir(self.next_release_path):
-            full_path = os.path.join(self.next_release_path, filename)
-            os.remove(full_path)
-        os.rmdir(self.next_release_path)
+            if filename.endswith('.json'):
+                full_path = os.path.join(self.next_release_path, filename)
+                os.remove(full_path)
+        # Remove next_release_path if the directory is empty
+        if not os.listdir(self.next_release_path):
+            click.echo("Removing '" + self.next_release_path + "' directory.")
+            os.rmdir(self.next_release_path)
 
     def list_changesets(self) -> List[Changeset]:
         changes: List[Changeset] = []

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DESCRIPTION = 'Manage properly semver in your repository'
 URL = 'https://github.com/raulgomis/semversioner'
 EMAIL = 'raulgomis@gmail.com'
 AUTHOR = 'Raul Gomis'
-REQUIRES_PYTHON = '>=3.7.0'
+REQUIRES_PYTHON = '>=3.8.0'
 VERSION = None
 REQUIRED = [
     'click>=8.0.0',
@@ -85,7 +85,7 @@ setup(
     install_requires=REQUIRED,
 
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
 
         'Environment :: Console',
 
@@ -96,10 +96,11 @@ setup(
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
     ],
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -39,8 +39,7 @@ def get_file(filename: str) -> Path:
 
 
 def read_file(filename: str) -> str:
-    text: str = files('email.tests.data').joinpath('message.eml').read_text()
-    return text
+    return files('tests.resources').joinpath(filename).read_text()  # type: ignore
 
 
 class CommandTest(unittest.TestCase):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -34,11 +34,13 @@ def single_command_processor(command: List[str], path: str) -> Result:
 
 
 def get_file(filename: str) -> Path: 
-    return files('tests.resources').joinpath(filename)  # type: ignore
+    path: Path = files('tests.resources').joinpath(filename)
+    return path
 
 
 def read_file(filename: str) -> str:
-    return files('tests.resources').joinpath(filename).read_text()  # type: ignore
+    text: str = files('email.tests.data').joinpath('message.eml').read_text()
+    return text
 
 
 class CommandTest(unittest.TestCase):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -40,31 +40,32 @@ def get_file(filename: str) -> Path:
 def read_file(filename: str) -> str:
     return files('tests.resources').joinpath(filename).read_text()  # type: ignore
 
+
 class TestUtilsParseKeyValue(unittest.TestCase):
 
-    def test_empty_input(self):
+    def test_empty_input(self) -> None:
         # Test case 1: Empty input
-        assert parse_key_value_pair(None, None, ()) is None
+        assert parse_key_value_pair(None, None, []) is None
 
-    def test_single_key_value_pair(self):
+    def test_single_key_value_pair(self) -> None:
         # Test case 2: Single key-value pair
         input1 = ['key1=value1']
         expected_output1 = {'key1': 'value1'}
         assert parse_key_value_pair(None, None, input1) == expected_output1
 
-    def test_multiple_key_value_pairs(self):
+    def test_multiple_key_value_pairs(self) -> None:
         # Test case 3: Multiple key-value pairs
         input2 = ['key1=value1', 'key2=value2', 'key3=value3']
         expected_output2 = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
         assert parse_key_value_pair(None, None, input2) == expected_output2
 
-    def test_special_characters_in_key_value_pairs(self):
+    def test_special_characters_in_key_value_pairs(self) -> None:
         # Test case 4: Key-value pairs with special characters
         input3 = ['key1=value1', 'key2=value2', 'key3=value3', 'key4=1+2=3=3']
         expected_output3 = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3', 'key4': '1+2=3=3'}
         assert parse_key_value_pair(None, None, input3) == expected_output3
 
-    def test_empty_values_in_key_value_pairs(self):
+    def test_empty_values_in_key_value_pairs(self) -> None:
         # Test case 5: Key-value pairs with empty values
         input4 = ['key1=', 'key2=value2', 'key3=']
         expected_output4 = {'key1': '', 'key2': 'value2', 'key3': ''}

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner, Result
 from importlib_resources import files
 
 from semversioner import __version__
-from semversioner.cli import cli
+from semversioner.cli import cli, parse_key_value_pair
 from tests import fixtures
 
 
@@ -39,6 +39,36 @@ def get_file(filename: str) -> Path:
 
 def read_file(filename: str) -> str:
     return files('tests.resources').joinpath(filename).read_text()  # type: ignore
+
+class TestUtilsParseKeyValue(unittest.TestCase):
+
+    def test_empty_input(self):
+        # Test case 1: Empty input
+        assert parse_key_value_pair(None, None, ()) is None
+
+    def test_single_key_value_pair(self):
+        # Test case 2: Single key-value pair
+        input1 = ['key1=value1']
+        expected_output1 = {'key1': 'value1'}
+        assert parse_key_value_pair(None, None, input1) == expected_output1
+
+    def test_multiple_key_value_pairs(self):
+        # Test case 3: Multiple key-value pairs
+        input2 = ['key1=value1', 'key2=value2', 'key3=value3']
+        expected_output2 = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+        assert parse_key_value_pair(None, None, input2) == expected_output2
+
+    def test_special_characters_in_key_value_pairs(self):
+        # Test case 4: Key-value pairs with special characters
+        input3 = ['key1=value1', 'key2=value2', 'key3=value3', 'key4=1+2=3=3']
+        expected_output3 = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3', 'key4': '1+2=3=3'}
+        assert parse_key_value_pair(None, None, input3) == expected_output3
+
+    def test_empty_values_in_key_value_pairs(self):
+        # Test case 5: Key-value pairs with empty values
+        input4 = ['key1=', 'key2=value2', 'key3=']
+        expected_output4 = {'key1': '', 'key2': 'value2', 'key3': ''}
+        assert parse_key_value_pair(None, None, input4) == expected_output4
 
 
 class CommandTest(unittest.TestCase):
@@ -199,7 +229,7 @@ class ChangelogCommandTest(CommandTest):
             ["release"],
             ["add-change", "--type", "major", "--description", "This is my major description"],
             ["add-change", "--type", "minor", "--description", "This is my minor description"],
-            ["add-change", "--type", "patch", "--description", "This is my patch description"],
+            ["add-change", "--type", "patch", "--description", "This is my patch description", "--attributes", "pr_id=322", "--attributes", "issue_id=123"],
             ["release"],
             ["changelog"]
         ]
@@ -218,6 +248,12 @@ class ChangelogCommandTest(CommandTest):
         ], self.directory_name)
 
         self.assertEqual(result.output, read_file("template_02_readme.md"))
+
+        result = command_processor([
+            ["changelog", "--template", str(get_file("template_03.j2"))]
+        ], self.directory_name)
+
+        self.assertEqual(result.output, read_file("template_03_readme.md"))
 
         result = command_processor([
             ["changelog"]

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -59,6 +59,21 @@ class CoreTestCase(unittest.TestCase):
         with self.assertRaises(MissingChangesetException):
             releaser.release()
 
+    def test_release_with_attributes(self) -> None:
+    
+            releaser = Semversioner(path=self.directory_name)
+
+            releaser.add_change("minor", "My description", attributes={"key": "value"})
+            releaser.add_change("major", "My description", attributes={"key2": "value2", "key3": "value3"})
+            self.assertEqual(releaser.get_status(), ReleaseStatus(version='0.0.0', next_version='1.0.0', unreleased_changes=[
+                Changeset(type='major', description='My description', attributes={"key2": "value2", "key3": "value3"}),
+                Changeset(type='minor', description='My description', attributes={"key": "value"})]
+            ))
+            releaser.release()
+            self.assertEqual(releaser.get_status(), ReleaseStatus(version='1.0.0', next_version=None, unreleased_changes=[]))
+            with self.assertRaises(MissingChangesetException):
+                releaser.release()
+
     def test_release_stress(self) -> None:
 
         releaser = Semversioner(path=self.directory_name)

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -60,19 +60,19 @@ class CoreTestCase(unittest.TestCase):
             releaser.release()
 
     def test_release_with_attributes(self) -> None:
-    
-            releaser = Semversioner(path=self.directory_name)
 
-            releaser.add_change("minor", "My description", attributes={"key": "value"})
-            releaser.add_change("major", "My description", attributes={"key2": "value2", "key3": "value3"})
-            self.assertEqual(releaser.get_status(), ReleaseStatus(version='0.0.0', next_version='1.0.0', unreleased_changes=[
-                Changeset(type='major', description='My description', attributes={"key2": "value2", "key3": "value3"}),
-                Changeset(type='minor', description='My description', attributes={"key": "value"})]
-            ))
+        releaser = Semversioner(path=self.directory_name)
+
+        releaser.add_change("minor", "My description", attributes={"key": "value"})
+        releaser.add_change("major", "My description", attributes={"key2": "value2", "key3": "value3"})
+        self.assertEqual(releaser.get_status(), ReleaseStatus(version='0.0.0', next_version='1.0.0', unreleased_changes=[
+            Changeset(type='major', description='My description', attributes={"key2": "value2", "key3": "value3"}),
+            Changeset(type='minor', description='My description', attributes={"key": "value"})]
+        ))
+        releaser.release()
+        self.assertEqual(releaser.get_status(), ReleaseStatus(version='1.0.0', next_version=None, unreleased_changes=[]))
+        with self.assertRaises(MissingChangesetException):
             releaser.release()
-            self.assertEqual(releaser.get_status(), ReleaseStatus(version='1.0.0', next_version=None, unreleased_changes=[]))
-            with self.assertRaises(MissingChangesetException):
-                releaser.release()
 
     def test_release_stress(self) -> None:
 

--- a/tests/resources/template_03.j2
+++ b/tests/resources/template_03.j2
@@ -1,0 +1,10 @@
+# Changelog
+Note: version releases in the 0.x.y range may introduce breaking changes.
+{% for release in releases %}
+
+## {{ release.version }} (<DATE>)
+
+{% for change in release.changes %}
+- {{ change.type }}: {{ change.description }}{{ ' (#' + change.attributes.pr_id + ')' if change.attributes }}{{ ' (J' + change.attributes.issue_id + ')' if change.attributes }}
+{% endfor %}
+{% endfor %}

--- a/tests/resources/template_03_readme.md
+++ b/tests/resources/template_03_readme.md
@@ -1,0 +1,14 @@
+# Changelog
+Note: version releases in the 0.x.y range may introduce breaking changes.
+
+## 2.0.0 (<DATE>)
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description (#322) (J123)
+
+## 1.0.0 (<DATE>)
+
+- major: This is my major description
+- minor: This is my minor description
+- patch: This is my patch description


### PR DESCRIPTION
- Drop support for Python 3.6 and 3.7 as they are not maintained. Minimum supported version is Python 3.8.
- Upgrade project third-party dependencies to latest version.
- Change deletion logic in `next-release` folder: only delete json files, and delete the folder only if empty. This will allow to keep the `next-release` folder if it contains other files such as `.gitkeep` for example.
- Add support for custom properties in changeset files.
- Change json mapper to use granurality of seconds instead of milliseconds for `created_at` field in releases.
- Clean up README Markdown syntax.