### PR TITLE
isolate check command updates

### DIFF
--- a/semversioner/cli.py
+++ b/semversioner/cli.py
@@ -141,10 +141,12 @@ def status(ctx: click.Context) -> None:
 
 
 @cli.command('check', help="Verifies changeset files exist.")
+@click.option('--src', '-s', required=False, default="**/*", help="A glob pattern for the source directory. Any changes here require semver impact. default=\"**/*\"")
+@click.option('--base', '-b', required=False, default="master", help="The base branch to compare against. default=master.")
 @click.pass_context
-def cli_check(ctx: click.Context) -> None:
+def cli_check(ctx: click.Context, src: str, base: str) -> None:
     releaser: Semversioner = ctx.obj['releaser']
-    if not releaser.check():
+    if not releaser.check(src, base):
         click.secho("Error: No changes to release.", fg='red')
         sys.exit(-1)
     else:

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -92,25 +92,24 @@ class CoreTestCase(unittest.TestCase):
         releaser = Semversioner(self.directory_name)
         self.assertFalse(releaser.is_deprecated())
 
-    def test_check_nok(self) -> None:
+    def test_has_changesets_nok(self) -> None:
+        releaser = Semversioner(path=self.directory_name)
+        self.assertFalse(releaser.has_changesets())
+
+    def test_has_changesets_ok(self) -> None:
 
         releaser = Semversioner(path=self.directory_name)
-        self.assertFalse(releaser.check())
 
-    def test_check_ok(self) -> None:
-
-        releaser = Semversioner(path=self.directory_name)
-
-        self.assertFalse(releaser.check())
+        self.assertFalse(releaser.has_changesets())
         releaser.add_change("major", "My description")
-        self.assertTrue(releaser.check())
+        self.assertTrue(releaser.has_changesets())
 
-    def test_check_after_release(self) -> None:
+    def test_has_changesets_after_release(self) -> None:
 
         releaser = Semversioner(path=self.directory_name)
         releaser.add_change("major", "My description")
         releaser.release()
-        self.assertFalse(releaser.check())
+        self.assertFalse(releaser.has_changesets())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates the `check` command to interact with git to ensure that there is a change-document for the current branch if any impacted files are touched.

Fixes #48 