### PR TITLE
Fix next-release folder recreation after release

### DIFF
--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -157,6 +157,11 @@ class SemversionerFileSystemStorage(SemversionerStorage):
             Absolute path of the file generated.
         """
 
+        # The directory might have been removed after a previous release when
+        # using the API directly. Ensure it exists before creating the file.
+        if not os.path.isdir(self.next_release_path):
+            os.makedirs(self.next_release_path)
+
         filename = None
         while (filename is None or os.path.isfile(os.path.join(self.next_release_path, filename))):
             filename = '{type_name}-{datetime}.json'.format(

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -112,6 +112,17 @@ class CoreTestCase(unittest.TestCase):
         releaser.release()
         self.assertFalse(releaser.check())
 
+    def test_add_change_after_release_same_instance(self) -> None:
+        """Ensure add_change works after a release using the same object."""
+
+        releaser = Semversioner(path=self.directory_name)
+        releaser.add_change("minor", "First")
+        releaser.release()
+
+        # Directory is removed during release but add_change should recreate it
+        path = releaser.add_change("patch", "Second")
+        self.assertTrue(os.path.isfile(path))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure storage creates the `next-release` folder if it was removed in a previous release
- add regression test for using the same `Semversioner` instance after release

## Testing
- `pytest tests/core_test.py::CoreTestCase::test_add_change_after_release_same_instance -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462f4f8af48327b3eab7d5a470264e