### PR TITLE
Fix changeset file creation race condition

### DIFF
--- a/.semversioner/next-release/patch-20250723122218419618.json
+++ b/.semversioner/next-release/patch-20250723122218419618.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix file creation race condition"
+}

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -157,17 +157,25 @@ class SemversionerFileSystemStorage(SemversionerStorage):
             Absolute path of the file generated.
         """
 
-        filename = None
-        while (filename is None or os.path.isfile(os.path.join(self.next_release_path, filename))):
+        # Ensure the next-release directory exists
+        os.makedirs(self.next_release_path, exist_ok=True)
+
+        # Retry loop with atomic file creation to prevent race conditions
+        while True:
             filename = '{type_name}-{datetime}.json'.format(
                 type_name=change.type,
                 datetime="{:%Y%m%d%H%M%S%f}".format(datetime.now(timezone.utc))
             )
-
-        with open(os.path.join(self.next_release_path, filename), 'w') as f:
-            f.write(json.dumps(change, cls=EnhancedJSONEncoder, indent=2) + "\n")
-
-        return os.path.join(self.next_release_path, filename)
+            full_path = os.path.join(self.next_release_path, filename)
+            
+            try:
+                # Use 'x' mode for exclusive creation - fails if file already exists
+                with open(full_path, 'x') as f:
+                    f.write(json.dumps(change, cls=EnhancedJSONEncoder, indent=2) + "\n")
+                return full_path
+            except FileExistsError:
+                # File already exists, retry with a new timestamp
+                continue
 
     def remove_all_changesets(self) -> None:
         click.echo("Removing changeset files in '" + self.next_release_path + "' directory.")

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -157,9 +157,6 @@ class SemversionerFileSystemStorage(SemversionerStorage):
             Absolute path of the file generated.
         """
 
-        # Ensure the next-release directory exists
-        os.makedirs(self.next_release_path, exist_ok=True)
-
         # Retry loop with atomic file creation to prevent race conditions
         while True:
             filename = '{type_name}-{datetime}.json'.format(


### PR DESCRIPTION
Refactor `create_changeset` to prevent race conditions during file creation.

The previous `create_changeset` method was vulnerable to race conditions due to a check-then-create pattern (`os.path.isfile` then `open`). This PR fixes it by using `open(..., 'x')` for atomic, exclusive file creation within a retry loop to handle potential filename collisions. The redundant `os.makedirs` call was also removed as directory existence is ensured by the constructor.