### PR TITLE
Add support for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.semversioner/next-release/patch-20241115120000.json
+++ b/.semversioner/next-release/patch-20241115120000.json
@@ -1,4 +1,4 @@
 {
-  "description": "Add Python 3.13 to supported versions and CI test matrix",
+  "description": "Add Python 3.14 to supported versions and CI test matrix",
   "type": "patch"
 }

--- a/.semversioner/next-release/patch-20241115120000.json
+++ b/.semversioner/next-release/patch-20241115120000.json
@@ -1,0 +1,4 @@
+{
+  "description": "Add Python 3.13 to supported versions and CI test matrix",
+  "type": "patch"
+}

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Operating System :: OS Independent',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Operating System :: OS Independent',
     ],
 


### PR DESCRIPTION
## Summary
- add Python 3.13 to project classifiers
- extend GitHub Actions test matrices to cover Python 3.13
- record upcoming release note for the new Python version support

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452bf17e6c832792d7eb83e3c5d732)