### PR TITLE
Add test coverage calculation and GitHub Actions integration

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -27,7 +27,13 @@ jobs:
         mypy semversioner tests
     - name: Build and test
       run: |
-        pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+        pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=semversioner --cov-report=term-missing --cov-report=xml
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-results-${{ matrix.python-version }}
+        path: coverage.xml
+      if: ${{ always() }}
     - name: Upload pytest test results
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,13 @@ jobs:
         mypy semversioner tests
     - name: Build and test
       run: |
-        pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+        pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=semversioner --cov-report=term-missing --cov-report=xml
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-results-${{ matrix.python-version }}
+        path: coverage.xml
+      if: ${{ always() }}
     - name: Upload pytest test results
       uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+coverage.xml
+junit/
 .tox
 nosetests.xml
 test-reports/

--- a/.semversioner/next-release/patch-20260412045212853378.json
+++ b/.semversioner/next-release/patch-20260412045212853378.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Add test coverage calculation and GitHub Actions integration"
+}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ lint:
 test:
 	@$(ENV)/bin/python -m pytest
 
+.PHONY: coverage
+coverage:
+	@$(ENV)/bin/python -m pytest --cov=semversioner --cov-report=term-missing
+
 .PHONY: clean
 clean:
 	@rm -vrf venv/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest==7.4.3
+pytest-cov==4.1.0
 importlib_resources==6.1.1
 mypy==1.8.0
 flake8==6.1.0


### PR DESCRIPTION
Add test coverage and GitHub Actions integration
- Install pytest-cov and update dev requirements
- Add 'coverage' target to Makefile
- Update CI/CD workflows to generate and upload coverage reports
- Update .gitignore for coverage.xml and junit folder
- Add patch changeset for current updates