### PR TITLE
Fix deserialization of Changesets in Release objects

### DIFF
--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -108,10 +108,13 @@ class ReleaseJsonMapper:
         if "created_at" in data:  # New format
             created_at = datetime.fromisoformat(data["created_at"])
             version = data["version"]
-            changes = sorted(data["changes"], key=lambda k: k["type"] + k["description"])
+            raw_changes = data["changes"]
         else:
-            changes = sorted(data, key=lambda k: k["type"] + k["description"])
+            raw_changes = data
             version = release_identifier
+
+        changes = [Changeset(**c) for c in raw_changes]
+        changes = sorted(changes, key=lambda k: k.type + k.description)
 
         return Release(version=version, changes=changes, created_at=created_at)
 


### PR DESCRIPTION
This PR fixes a bug in the `feature/next-major-v3` branch where `Release` objects loaded from storage had their `changes` list populated with raw dictionaries instead of `Changeset` objects. This led to potential runtime errors when the core logic tried to access attributes on these changes.

The fix involves updating `ReleaseJsonMapper.from_json` in `semversioner/storage.py` to explicitly instantiate `Changeset` objects from the raw data.

Additionally, this change refactors the mapping logic to be more concise and maintainable by extracting common logic outside of the format-detection conditional blocks.

---
*PR created automatically by Jules for task [3904832413148880033](https://jules.google.com/task/3904832413148880033) started by @raulgomis*