### PR TITLE
Fix next-release folder recreation after release

### DIFF
--- a/.semversioner/next-release/patch-20260607074511239035.json
+++ b/.semversioner/next-release/patch-20260607074511239035.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix next-release folder recreation after release."
+}

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -159,6 +159,9 @@ class SemversionerFileSystemStorage(SemversionerStorage):
             Absolute path of the file generated.
         """
 
+        if not self.next_release_path.is_dir():
+            self.next_release_path.mkdir(parents=True)
+
         # Retry loop with atomic file creation to prevent race conditions
         while True:
             filename = f"{change.type}-{datetime.now(timezone.utc):%Y%m%d%H%M%S%f}.json"

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -161,3 +161,14 @@ def test_check_after_release(directory_name: str) -> None:
     releaser.add_change("major", "My description")
     releaser.release()
     assert not releaser.check()
+
+
+def test_add_change_after_release_same_instance(directory_name: str) -> None:
+    """Ensure add_change works after a release using the same object."""
+    releaser = Semversioner(path=directory_name)
+    releaser.add_change("minor", "First")
+    releaser.release()
+
+    # Directory is removed during release but add_change should recreate it
+    path = releaser.add_change("patch", "Second")
+    assert os.path.isfile(path)


### PR DESCRIPTION
## Description

Reusing the same core instance programmatically across multiple releases raised a `FileNotFoundError` when adding subsequent changesets. 

## Steps to reproduce

```
    releaser = Semversioner(path=directory_name)
    releaser.add_change("minor", "First")
    releaser.release()
    releaser.add_change("patch", "Second")
```
## Fix
To resolve this, we updated the `create_changeset` method in `storage.py` to check for the directory's existence and recreate it if necessary just-in-time.