### PR TITLE
🔒 Fix Server-Side Template Injection (SSTI) in Jinja2

### DIFF
--- a/.semversioner/next-release/patch-20260612215608465973.json
+++ b/.semversioner/next-release/patch-20260612215608465973.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix Server-Side Template Injection (SSTI) in Jinja2 by using SandboxedEnvironment"
+}

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from semversioner.models import (
     Changeset,
@@ -78,7 +78,7 @@ class Semversioner:
             releases = [x for x in releases if x.version == version]
 
         current_version = self.get_last_version()
-        return Template(template, trim_blocks=True).render(
+        return SandboxedEnvironment(trim_blocks=True).from_string(template).render(
             releases=releases,
             current_version=current_version,
         )

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import tempfile
+import pytest
+from jinja2.exceptions import SecurityError
+from semversioner import Semversioner
+
+@pytest.fixture
+def directory_name():
+    dir_name = tempfile.mkdtemp()
+    yield dir_name
+    shutil.rmtree(dir_name)
+
+def test_generate_changelog_ssti_protection(directory_name: str) -> None:
+    """
+    Test that the changelog generation is protected against SSTI.
+    """
+    releaser = Semversioner(path=directory_name)
+
+    # Payload attempting to access unsafe attributes
+    payload = "{{ self.__init__.__globals__['__builtins__'] }}"
+
+    with pytest.raises(SecurityError) as excinfo:
+        releaser.generate_changelog(template=payload)
+
+    assert "access to attribute '__init__' of 'TemplateReference' object is unsafe" in str(excinfo.value)
+
+def test_generate_changelog_safe_template(directory_name: str) -> None:
+    """
+    Test that a normal, safe template still works.
+    """
+    releaser = Semversioner(path=directory_name)
+    releaser.add_change("minor", "Safe change")
+    releaser.release()
+
+    template = "Version: {{ current_version }}"
+    result = releaser.generate_changelog(template=template)
+
+    assert "Version: 0.1.0" in result


### PR DESCRIPTION
The `generate_changelog` method used `jinja2.Template` directly with user-provided templates, which was vulnerable to Server-Side Template Injection (SSTI). This change switches to `jinja2.sandbox.SandboxedEnvironment`, which restricts access to unsafe attributes and prevents arbitrary code execution from malicious templates.

🎯 **What:** Server-Side Template Injection (SSTI) in Jinja2
⚠️ **Risk:** Arbitrary code execution via malicious templates provided via the `--template` CLI option.
🛡️ **Solution:** Use Jinja2 SandboxedEnvironment to render templates.

Added regression tests in `tests/security_test.py`.

---
*PR created automatically by Jules for task [16433289225994427680](https://jules.google.com/task/16433289225994427680) started by @raulgomis*