### PR TITLE
🧹 [code health improvement] Use generator for release numbers retrieval

### DIFF
--- a/.semversioner/next-release/patch-20260612230614671643.json
+++ b/.semversioner/next-release/patch-20260612230614671643.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Refactor list release numbers to use generator for better readability"
+}

--- a/semversioner/storage.py
+++ b/semversioner/storage.py
@@ -223,5 +223,8 @@ class SemversionerFileSystemStorage(SemversionerStorage):
         return None
 
     def _list_release_numbers(self) -> list[str]:
-        files = [f.name for f in self.semversioner_path.iterdir() if f.is_file()]
-        return sorted((x[: -len(".json")] for x in files if x.endswith(".json")), key=lambda x: parse(x), reverse=True)
+        return sorted(
+            (f.stem for f in self.semversioner_path.iterdir() if f.is_file() and f.suffix == ".json"),
+            key=parse,
+            reverse=True,
+        )


### PR DESCRIPTION
### 🎯 What
Refactored `_list_release_numbers` in `semversioner/storage.py` to use a single chained generator expression instead of an intermediate list.

### 💡 Why
Improves readability and memory efficiency by avoiding intermediate list creation and using idiomatic `pathlib` properties (`.stem`, `.suffix`). It also simplifies the sort key.

### ✅ Verification
- Ran `make lint` to ensure code style compliance.
- Ran `make test` (all 48 tests passed) to ensure no regressions.

### ✨ Result
Cleaner and more efficient code for listing release numbers.

---
*PR created automatically by Jules for task [14265940707109415668](https://jules.google.com/task/14265940707109415668) started by @raulgomis*