### PR TITLE
Fix Server-Side Template Injection (SSTI) in Jinja2

### DIFF
--- a/.semversioner/next-release/patch-20260612215608465973.json
+++ b/.semversioner/next-release/patch-20260612215608465973.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix Server-Side Template Injection (SSTI) in Jinja2 by using SandboxedEnvironment"
+}

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from semversioner.models import (
     Changeset,
@@ -78,7 +78,7 @@ class Semversioner:
             releases = [x for x in releases if x.version == version]
 
         current_version = self.get_last_version()
-        return Template(template, trim_blocks=True).render(
+        return SandboxedEnvironment(trim_blocks=True).from_string(template).render(
             releases=releases,
             current_version=current_version,
         )

--- a/semversioner/core.py
+++ b/semversioner/core.py
@@ -78,9 +78,13 @@ class Semversioner:
             releases = [x for x in releases if x.version == version]
 
         current_version = self.get_last_version()
-        return SandboxedEnvironment(trim_blocks=True).from_string(template).render(
-            releases=releases,
-            current_version=current_version,
+        return (
+            SandboxedEnvironment(trim_blocks=True)
+            .from_string(template)
+            .render(
+                releases=releases,
+                current_version=current_version,
+            )
         )
 
     def release(self) -> Release:

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import tempfile
+import pytest
+from jinja2.exceptions import SecurityError
+from semversioner import Semversioner
+
+@pytest.fixture
+def directory_name():
+    dir_name = tempfile.mkdtemp()
+    yield dir_name
+    shutil.rmtree(dir_name)
+
+def test_generate_changelog_ssti_protection(directory_name: str) -> None:
+    """
+    Test that the changelog generation is protected against SSTI.
+    """
+    releaser = Semversioner(path=directory_name)
+
+    # Payload attempting to access unsafe attributes
+    payload = "{{ self.__init__.__globals__['__builtins__'] }}"
+
+    with pytest.raises(SecurityError) as excinfo:
+        releaser.generate_changelog(template=payload)
+
+    assert "access to attribute '__init__' of 'TemplateReference' object is unsafe" in str(excinfo.value)
+
+def test_generate_changelog_safe_template(directory_name: str) -> None:
+    """
+    Test that a normal, safe template still works.
+    """
+    releaser = Semversioner(path=directory_name)
+    releaser.add_change("minor", "Safe change")
+    releaser.release()
+
+    template = "Version: {{ current_version }}"
+    result = releaser.generate_changelog(template=template)
+
+    assert "Version: 0.1.0" in result

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -1,15 +1,18 @@
-import os
 import shutil
 import tempfile
+
 import pytest
 from jinja2.exceptions import SecurityError
+
 from semversioner import Semversioner
+
 
 @pytest.fixture
 def directory_name():
     dir_name = tempfile.mkdtemp()
     yield dir_name
     shutil.rmtree(dir_name)
+
 
 def test_generate_changelog_ssti_protection(directory_name: str) -> None:
     """
@@ -24,6 +27,7 @@ def test_generate_changelog_ssti_protection(directory_name: str) -> None:
         releaser.generate_changelog(template=payload)
 
     assert "access to attribute '__init__' of 'TemplateReference' object is unsafe" in str(excinfo.value)
+
 
 def test_generate_changelog_safe_template(directory_name: str) -> None:
     """


### PR DESCRIPTION
## Summary

This PR prevents Server-Side Template Injection (SSTI) when generating changelogs from custom Jinja2 templates.

## Changes

- Replaces the standard Jinja2 `Template` with `SandboxedEnvironment`.
- Prevents templates from accessing unsafe Python attributes and internals.
- Adds regression tests covering:
  - Attempts to access unsafe template attributes.
  - Successful rendering of legitimate custom templates.
- Adds a Semversioner patch changeset.
- Applies Ruff formatting and import cleanup.

## Why

Custom changelog templates were previously rendered without sandboxing. A malicious template could potentially access Python internals and execute unintended operations.

Using Jinja2's sandbox preserves normal changelog template functionality while blocking unsafe attribute access.

## Validation

- `make lint` passes.
- `make test` passes with all 50 tests successful.